### PR TITLE
Parsing JSON API error

### DIFF
--- a/json_api_doc/__init__.py
+++ b/json_api_doc/__init__.py
@@ -10,6 +10,9 @@ def parse(content):
     :param content: A JSON API document already
     :returns: The JSON API document parsed
     """
+    if "errors" in content:
+        return content
+
     if "data" not in content:
         raise AttributeError("This is not a JSON API document")
 

--- a/tests/test_simple.py
+++ b/tests/test_simple.py
@@ -85,3 +85,15 @@ def test_simple_list():
 def test_invalid():
     with pytest.raises(AttributeError):
         json_api_doc.parse({"a": 1})
+
+
+def test_error():
+    response = {
+        "errors":[{
+            "status":"404",
+            "title":"not found",
+            "detail":"Resource not found"
+        }]
+    }
+    doc = json_api_doc.parse(response)
+    assert doc == response


### PR DESCRIPTION
JSON API supports error responses, but parsing such objects incorrectly raises `AttributeError("This is not a JSON API document")`.

Because JSON API spec is not terribly exact when it comes to error object, I opted to simply return the content without altering it.