### PR TITLE
Use errors input instead of meta on serialize

### DIFF
--- a/json_api_doc/serialization.py
+++ b/json_api_doc/serialization.py
@@ -31,7 +31,7 @@ def serialize(data={}, errors={}, meta={}):
         res["meta"] = meta
 
     if errors:
-        res["errors"] = meta
+        res["errors"] = errors
 
     return res or {"data": None}
 

--- a/tests/test_serialize.py
+++ b/tests/test_serialize.py
@@ -231,6 +231,20 @@ def test_serialize_meta():
     }
 
 
+def test_serialize_errors():
+    errors = {
+        "some": "random",
+        "silly": "data"
+    }
+    doc = json_api_doc.serialize(errors=errors)
+    assert doc == {
+        "errors": {
+            "some": "random",
+            "silly": "data"
+        }
+    }
+
+
 def test_serialize_object_deep():
     data = {
         "$type": "article",


### PR DESCRIPTION
If errors are passed in as an arugment to `serialize` they are not actually used in creating the `errors` section of the JSON:API output; instead `meta` is used. So, in order to actually get the errors to show up, you would need to do something along the lines of `json_api_doc.serialize(errors=errors, meta=errors)` but then the errors are in both the `errors` and `meta` section.

This commit fixes it so that if errors are passed in to a `serialize` call they are correctly added to the JSON:API output.