### PR TITLE
Add links to serialize

### DIFF
--- a/json_api_doc/serialization.py
+++ b/json_api_doc/serialization.py
@@ -3,7 +3,7 @@
 from collections import OrderedDict
 
 
-def serialize(data={}, errors={}, meta={}):
+def serialize(data={}, errors={}, meta={}, links={}):
     """
     :param data: Dict with data to serialize
     :param errors: Dict with error data to serialize
@@ -32,6 +32,9 @@ def serialize(data={}, errors={}, meta={}):
 
     if errors:
         res["errors"] = errors
+
+    if links:
+        res["links"] = links
 
     return res or {"data": None}
 

--- a/tests/test_serialize.py
+++ b/tests/test_serialize.py
@@ -245,6 +245,30 @@ def test_serialize_errors():
     }
 
 
+def test_serialize_links():
+    links = {
+        "some": "random",
+        "silly": {
+            "href": "random",
+            "meta": {
+                "silly": "data"
+            }
+        }
+    }
+    doc = json_api_doc.serialize(links=links)
+    assert doc == {
+        "links": {
+            "some": "random",
+            "silly": {
+                "href": "random",
+                "meta": {
+                    "silly": "data"
+                }
+            }
+        }
+    }
+
+
 def test_serialize_object_deep():
     data = {
         "$type": "article",


### PR DESCRIPTION
A document may contain a [links object](https://jsonapi.org/format/#document-links) representing a group of links at the [top level](https://jsonapi.org/format/#document-top-level). 

If someone wants to create a document with links, i.e. for pagination, those should be included for serialization.