### PR TITLE
Resolve relationships with meta

### DIFF
--- a/json_api_doc/deserialization.py
+++ b/json_api_doc/deserialization.py
@@ -31,17 +31,23 @@ def deserialize(content):
 
 
 def _resolve(data, included, resolved):
-    if set(data.keys()) == {"type", "id"}:
+    if not isinstance(data, dict):
+        return data
+    keys = data.keys()
+    if keys == {"type", "id"} or keys == {"type", "id", "meta"}:
         type_id = data["type"], data["id"]
+        meta = data.get("meta")
         resolved_item = included.get(type_id, data)
-        if type_id in resolved:
-            return data
-        else:
-            return _resolve(
+        if type_id not in resolved:
+            data = _resolve(
                 resolved_item,
                 included,
                 resolved | {type_id}
             )
+        if meta is not None:
+            data = data.copy()
+            data.update(meta=meta)
+        return data
     for key, value in data.items():
         if isinstance(value, dict):
             data[key] = _resolve(value, included, resolved)

--- a/tests/test_relationships.py
+++ b/tests/test_relationships.py
@@ -91,6 +91,23 @@ def test_resolve():
     }
 
 
+def test_resolve_with_meta():
+    included = {
+        ("people", "9"): {
+            "name": "Jean"
+        }
+    }
+    data = {
+        "title": "Article 1",
+        "author": {"type": "people", "id": "9", "meta": {"index": 3}}
+    }
+    doc = json_api_doc._resolve(data, included, set())
+    assert doc == {
+        "title": "Article 1",
+        "author": {"name": "Jean", "meta": {"index": 3}}
+    }
+
+
 def test_resolve_missing():
     included = {
     }
@@ -127,6 +144,32 @@ def test_resolve_list():
         "authors": [
             {"name": "Jean"},
             {"name": "Luc"},
+        ]
+    }
+
+
+def test_resolve_list_with_meta():
+    included = {
+        ("people", "9"): {
+            "name": "Jean"
+        },
+        ("people", "10"): {
+            "name": "Luc"
+        }
+    }
+    data = {
+        "title": "Article 1",
+        "authors": [
+            {"type": "people", "id": "9", "meta": {"index": 3}},
+            {"type": "people", "id": "10", "meta": {"index": 18}},
+        ]
+    }
+    doc = json_api_doc._resolve(data, included, set())
+    assert doc == {
+        "title": "Article 1",
+        "authors": [
+            {"name": "Jean", "meta": {"index": 3}},
+            {"name": "Luc", "meta": {"index": 18}},
         ]
     }
 
@@ -243,6 +286,44 @@ def test_simple_relationships():
             "id": "9",
             "first-name": "Bob",
             "last-name": "Doe"
+        }
+    }
+
+
+def test_simple_relationships_with_meta():
+    response = {
+        "data": {
+            "type": "article",
+            "id": "1",
+            "attributes": {
+                "title": "Article 1"
+            },
+            "relationships": {
+                "author": {
+                    "data": {"type": "people", "id": "9", "meta": {"index": 3}}
+                }
+            }
+        },
+        "included": [{
+            "type": "people",
+            "id": "9",
+            "attributes": {
+                "first-name": "Bob",
+                "last-name": "Doe",
+            }
+        }]
+    }
+    doc = json_api_doc.parse(response)
+    assert doc == {
+        "type": "article",
+        "id": "1",
+        "title": "Article 1",
+        "author": {
+            "type": "people",
+            "id": "9",
+            "first-name": "Bob",
+            "last-name": "Doe",
+            "meta": {"index": 3}
         }
     }
 


### PR DESCRIPTION
Proposed fix for https://github.com/noplay/json-api-doc/issues/12.
In this approach `meta` is attached to the resolved object as-is without flattening into it.