### PR TITLE
Prevent maximum recursion errors when resolving deeply nested m2m fields

### DIFF
--- a/json_api_doc/deserialization.py
+++ b/json_api_doc/deserialization.py
@@ -30,7 +30,7 @@ def deserialize(content):
         return None
 
 
-def _resolve(data, included, resolved):
+def _resolve(data, included, resolved, deep=True):
     if not isinstance(data, dict):
         return data
     keys = data.keys()
@@ -52,10 +52,11 @@ def _resolve(data, included, resolved):
         if isinstance(value, dict):
             data[key] = _resolve(value, included, resolved)
         elif isinstance(value, list):
-            data[key] = [
-                _resolve(item, included, resolved)
-                for item in value
-            ]
+            if deep:
+                data[key] = [
+                    _resolve(item, included, resolved, False)
+                    for item in value
+                ]
         else:
             data[key] = value
     return data

--- a/tests/test_deserialize.py
+++ b/tests/test_deserialize.py
@@ -71,3 +71,93 @@ def test_first_level_data_in_included():
             }
         }
     }
+
+def test_can_handle_deep_recursive_relationships():
+    response = {
+        'data': {
+            'type': 'Version',
+            'id': '1',
+            'attributes': {},
+            'relationships': {
+                'drivers': {
+                    'meta': {'count': 1},
+                    'data': [{'type': 'Driver', 'id': '1'}]
+                },
+                'named_insureds': {
+                    'meta': {'count': 1},
+                    'data': [{'type': 'NamedInsured', 'id': '1'}]
+                },
+                'losses': {
+                    'meta': {'count': 1},
+                    'data': [{'type': 'Loss', 'id': '1'}]
+                },
+            }
+        },
+        'included': [
+            {
+                'type': 'Address',
+                'id': '1',
+                'attributes': {},
+                'relationships':
+                    {
+                        'entities': {
+                            'meta': {'count': 1},
+                            'data': [{'type': 'Entity', 'id': '1'}]
+                        },
+                        'info': {
+                            'meta': {'count': 1},
+                            'data': [{'type': 'AddressInfo', 'id': '1'}]
+                        }
+                    }
+            }, {
+                'type': 'AddressInfo',
+                'id': '1',
+                'attributes': {},
+                'relationships': {
+                    'address': {
+                        'data': {'type': 'Address', 'id': '1'}
+                    }
+                }
+            }, {
+                'type': 'Driver',
+                'id': '1',
+                'attributes': {},
+                'relationships': {
+                    'entity': {
+                        'data': {'type': 'Entity', 'id': '1'}
+                    }
+                }
+            }, {
+                'type': 'Entity',
+                'id': '1',
+                'attributes': {},
+                'relationships': {
+                    'addresses': {
+                        'meta': {'count': 1},
+                        'data': [{'type': 'Address', 'id': '1'}]
+                    }
+                }
+            }, {
+                'type': 'Loss',
+                'id': '1',
+                'attributes': {},
+                'relationships': {
+                    'address': {
+                        'data': {'type': 'Address', 'id': '1'}
+                    },
+                }
+            }, {
+                'type': 'NamedInsured',
+                'id': '1',
+                'attributes': {},
+                'relationships': {
+                    'entity': {
+                        'data': {'type': 'Entity', 'id': '1'}
+                    }
+                }
+            },
+        ]
+    }
+    doc = json_api_doc.deserialize(response)
+    assert bool(doc["drivers"][0]["entity"]["addresses"][0]["info"]) is True
+    assert bool(doc["losses"][0]["address"]) is True

--- a/tests/test_deserialize.py
+++ b/tests/test_deserialize.py
@@ -74,85 +74,85 @@ def test_first_level_data_in_included():
 
 def test_can_handle_deep_recursive_relationships():
     response = {
-        'data': {
-            'type': 'Version',
-            'id': '1',
-            'attributes': {},
-            'relationships': {
-                'drivers': {
-                    'meta': {'count': 1},
-                    'data': [{'type': 'Driver', 'id': '1'}]
+        "data": {
+            "type": "Version",
+            "id": "1",
+            "attributes": {},
+            "relationships": {
+                "drivers": {
+                    "meta": {"count": 1},
+                    "data": [{"type": "Driver", "id": "1"}]
                 },
-                'named_insureds': {
-                    'meta': {'count': 1},
-                    'data': [{'type': 'NamedInsured', 'id': '1'}]
+                "named_insureds": {
+                    "meta": {"count": 1},
+                    "data": [{"type": "NamedInsured", "id": "1"}]
                 },
-                'losses': {
-                    'meta': {'count': 1},
-                    'data': [{'type': 'Loss', 'id': '1'}]
+                "losses": {
+                    "meta": {"count": 1},
+                    "data": [{"type": "Loss", "id": "1"}]
                 },
             }
         },
-        'included': [
+        "included": [
             {
-                'type': 'Address',
-                'id': '1',
-                'attributes': {},
-                'relationships':
+                "type": "Address",
+                "id": "1",
+                "attributes": {},
+                "relationships":
                     {
-                        'entities': {
-                            'meta': {'count': 1},
-                            'data': [{'type': 'Entity', 'id': '1'}]
+                        "entities": {
+                            "meta": {"count": 1},
+                            "data": [{"type": "Entity", "id": "1"}]
                         },
-                        'info': {
-                            'meta': {'count': 1},
-                            'data': [{'type': 'AddressInfo', 'id': '1'}]
+                        "info": {
+                            "meta": {"count": 1},
+                            "data": [{"type": "AddressInfo", "id": "1"}]
                         }
                     }
             }, {
-                'type': 'AddressInfo',
-                'id': '1',
-                'attributes': {},
-                'relationships': {
-                    'address': {
-                        'data': {'type': 'Address', 'id': '1'}
+                "type": "AddressInfo",
+                "id": "1",
+                "attributes": {},
+                "relationships": {
+                    "address": {
+                        "data": {"type": "Address", "id": "1"}
                     }
                 }
             }, {
-                'type': 'Driver',
-                'id': '1',
-                'attributes': {},
-                'relationships': {
-                    'entity': {
-                        'data': {'type': 'Entity', 'id': '1'}
+                "type": "Driver",
+                "id": "1",
+                "attributes": {},
+                "relationships": {
+                    "entity": {
+                        "data": {"type": "Entity", "id": "1"}
                     }
                 }
             }, {
-                'type': 'Entity',
-                'id': '1',
-                'attributes': {},
-                'relationships': {
-                    'addresses': {
-                        'meta': {'count': 1},
-                        'data': [{'type': 'Address', 'id': '1'}]
+                "type": "Entity",
+                "id": "1",
+                "attributes": {},
+                "relationships": {
+                    "addresses": {
+                        "meta": {"count": 1},
+                        "data": [{"type": "Address", "id": "1"}]
                     }
                 }
             }, {
-                'type': 'Loss',
-                'id': '1',
-                'attributes': {},
-                'relationships': {
-                    'address': {
-                        'data': {'type': 'Address', 'id': '1'}
+                "type": "Loss",
+                "id": "1",
+                "attributes": {},
+                "relationships": {
+                    "address": {
+                        "data": {"type": "Address", "id": "1"}
                     },
                 }
             }, {
-                'type': 'NamedInsured',
-                'id': '1',
-                'attributes': {},
-                'relationships': {
-                    'entity': {
-                        'data': {'type': 'Entity', 'id': '1'}
+                "type": "NamedInsured",
+                "id": "1",
+                "attributes": {},
+                "relationships": {
+                    "entity": {
+                        "data": {"type": "Entity", "id": "1"}
                     }
                 }
             },


### PR DESCRIPTION
Ran into this issue in my system. It definitely seems edge case, but it was completely blocking a feature from being completed. Basically, the models are recursive (because of the m2m), which `json-api-doc` handles, but the fact that multiple other models have a FK to the recursive models eventually gets the `_resolve` method stuck in a loop that doesn't end. The solution that I was able to find was preventing the `_resolve` method from looping more than 1 level deep at a time. This appears to solve the issue without causing a regression in functionality.

The test I wrote has the models from my app without any attributes. We can change the names of these models if desired. 

I am definitely open to suggestions or alternative approaches. Let me know if you want something changed or need more info from me.

Thank you!