### PR TITLE
Serialize an empty list correctly

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,6 @@ language: python
 python:
 - 3.6
 - 3.5
-- 3.4
 install: pip install -U tox-travis
 script: tox
 deploy:

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -103,7 +103,7 @@ Before you submit a pull request, check that it meets these guidelines:
 2. If the pull request adds functionality, the docs should be updated. Put
    your new functionality into a function with a docstring, and add the
    feature to the list in README.rst.
-3. The pull request should work for Python 3.4, 3.5 and 3.6, and for PyPy. Check
+3. The pull request should work for Python 3.5 and 3.6, and for PyPy. Check
    https://travis-ci.org/noplay/json-api-doc/pull_requests
    and make sure that the tests pass for all supported Python versions.
 

--- a/json_api_doc/serialization.py
+++ b/json_api_doc/serialization.py
@@ -23,6 +23,8 @@ def serialize(data={}, errors={}, meta={}, links={}):
                 map(lambda item: _serialize(item, included), data))
         else:
             res["data"] = _serialize(data, included)
+    elif isinstance(data, list):
+        res["data"] = []
 
     if included:
         res["included"] = list(included.values())

--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,6 @@ setup(
         'License :: OSI Approved :: Apache Software License',
         'Natural Language :: English',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.4',
         'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',
     ],

--- a/tests/test_serialize.py
+++ b/tests/test_serialize.py
@@ -54,6 +54,12 @@ def test_serialize_object_list():
         }]
     }
 
+def test_serialize_empty_list():
+    doc = json_api_doc.serialize([])
+    assert doc == {
+        "data": []
+    }
+
 
 def test_serialize_object_without_attributes():
     data = {

--- a/tox.ini
+++ b/tox.ini
@@ -8,7 +8,6 @@ ignore=E402,E741
 python =
     3.6: py36
     3.5: py35
-    3.4: py34
 
 [testenv:flake8]
 basepython = python


### PR DESCRIPTION
Correct `json_api_doc.serialize([])` to return `{'data': []}`.

The JSON API specification stipulates that a logical collection of
resources MUST be represented as an array, even if it only contains one
item or is empty.

Fixes issue #16.