### PR TITLE
fix infinite recursion due to cyclic 'included's

### DIFF
--- a/json_api_doc/deserialization.py
+++ b/json_api_doc/deserialization.py
@@ -38,6 +38,7 @@ def _resolve(data, included, resolved, deep=True):
         type_id = data["type"], data["id"]
         meta = data.get("meta")
         resolved_item = included.get(type_id, data)
+        resolved_item = resolved_item.copy()
         if type_id not in resolved:
             data = _resolve(
                 resolved_item,


### PR DESCRIPTION
In using this library, I have encountered a few situations where the structure of the 'included'entries and 'data' entries leads to an infinite recursion in the `_resolve` method.

I believe the issue is due to elements of the flattened `included` dictionary being modified as the algorithm progresses, leading to 'scope-creep' in what needs to be resolved, and going infinite when the conditions are just right. This was prevented by creating a copy of those entries instead. The example used in the test is about as small as I can make it, though some simplification may still be possible.

[Note: I first thought `resolved` needed to keep track of global state, but that approach only properly copied attributes the first time an item was resolved. My second approach of returning `resolved_item` when something had already been resolved created a seemingly correct circularly-nested dictionary, breaking tests designed to prevent this. I have hopefully correctly deduced that each item should be expanded once per data item: if an entry were to create a loop, only then is it left as an empty identifier.]